### PR TITLE
Revise security policy for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+**PLEASE DON'T DISCLOSE SECURITY-RELATED ISSUES PUBLICLY, [SEE BELOW](#reporting-a-vulnerability).**
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately using one of the following channels:
+
+1. **GitHub Private Vulnerability Reporting** (preferred) — go to the repository's **Security** tab and click **"Report a vulnerability"**. This creates a private advisory visible only to maintainers and provides a structured workflow for triage, fix coordination, and CVE assignment.
+
+2. **Email** — send the details to [TouwfiQ Meghlaoui] at **touwfiqdev@gmail.com**.
+
+All security vulnerabilities will be promptly addressed.


### PR DESCRIPTION
Updated the security policy to emphasize private reporting of vulnerabilities and removed the supported versions table.